### PR TITLE
Update onboard-vendors-to-techpass.md

### DIFF
--- a/docs/onboard-vendors-to-techpass.md
+++ b/docs/onboard-vendors-to-techpass.md
@@ -7,7 +7,7 @@ If you are a vendor or contractor who does not have an active TechPass account, 
 
 ?>
   You can use this TechPass account to access SGTS products and services.<br><br>
-  If you are a public officer or a user with a <i>user_name<span>@</span>gov.sg</i> email address, please refer to [Onboarding Public Officers](onboard-public-officers-using-non-se-machines).
+  If you are a public officer with a <i>user_name<span>@</span>gov.sg</i> email address, please refer to [Onboarding Public Officers](onboard-public-officers-using-non-se-machines).
 
 
 ## Onboarding vendor


### PR DESCRIPTION
[If you are a public officer or user with a @tech.gov.sg email address] to [If you are a public officer with a @tech.gov.sg email address] - as per earlier discussion, I thought the team wanted to keep it clean with all vendors or contractor using @techpass.gov.sg account rather than tap on WOG AAD?