### PR TITLE
Adding 2 FAQ for account management

### DIFF
--- a/docs/register-intune-device-id.md
+++ b/docs/register-intune-device-id.md
@@ -49,7 +49,7 @@ Following are the prerequisites to register Intune device ID on TechPass portal:
 
 6. Choose the appropriate step:
 
-   a. If you have received a successfully onboarded email, skip rest of the steps in this section and proceed to [Step 3: Verify installation](https://docs.developer.tech.gov.sg/docs/security-suite-for-engineering-endpoint-devices-seed/onboard-device/mac-os?id=step-3-verify-installation).
+   a. If you have received a successfully onboarded email, skip rest of the steps in this section and proceed to [Step 3: Verify installation](https://docs.developer.tech.gov.sg/docs/security-suite-for-engineering-endpoint-devices/onboard-device/mac-os?id=step-3-verify-installation).
 
    b. If you have **not yet received** the **successfully onboarded email** or if you **have received** a **failed onboarding email**, complete the following step on [TechPass portal](https://portal.techpass.gov.sg/).
 

--- a/docs/support/account.md
+++ b/docs/support/account.md
@@ -101,7 +101,7 @@ You might encounter this error if you are trying to sign in to your WOG account 
 <details>
 <summary style="font-size:18px">I have changed my email address, how do I update my TechPass account?</summary>
 
-Create a [service-request]: https://go.gov.sg/seed-techpass-support and we will trigger a reinvite to retectify the issue.
+Create a [service-request](https://go.gov.sg/seed-techpass-support) and we will trigger a reinvite to retectify the issue.
 
 
 <hr/></details><br>

--- a/docs/support/account.md
+++ b/docs/support/account.md
@@ -97,6 +97,25 @@ You might encounter this error if you are trying to sign in to your WOG account 
 
 <hr/></details><br>
 
+
+<details>
+<summary style="font-size:18px">I have changed my email address, how do I update my TechPass account?</summary>
+
+Create a [service-request]: https://go.gov.sg/seed-techpass-support and we will trigger a reinvite to retectify the issue.
+
+
+<hr/></details><br>
+
+<details>
+<summary style="font-size:18px">I would like to terminate my TechPass account, what should I do?</summary>
+
+If you have a SEED device, offboard your SEED device by following the [offboarding guide]: https://docs.developer.tech.gov.sg/docs/security-suite-for-engineering-endpoint-devices/offboard-device/offboard-device-from-seed. After offbarding your SEED device, create a [service-request]: https://go.gov.sg/seed-techpass-support. Upon verification, we will teminate the TechPass account.
+
+If you do not have a SEED device, create a [service-request]: https://go.gov.sg/seed-techpass-support. Upon verification, we will teminate the TechPass account.
+
+
+<hr/></details><br>
+
 [reset-password]: https://passwordreset.microsoftonline.com/
 [password-policy-of-azure-active-directory]: https://docs.microsoft.com/en-us/azure/active-directory/authentication/concept-sspr-policy#administrator-password-policy-differences
 [reset-password-gsib]: https://itsm.sgnet.gov.sg/sp3

--- a/docs/support/account.md
+++ b/docs/support/account.md
@@ -109,9 +109,9 @@ Create a [service-request]: https://go.gov.sg/seed-techpass-support and we will 
 <details>
 <summary style="font-size:18px">I would like to terminate my TechPass account, what should I do?</summary>
 
-If you have a SEED device, offboard your SEED device by following the [offboarding guide]: https://docs.developer.tech.gov.sg/docs/security-suite-for-engineering-endpoint-devices/offboard-device/offboard-device-from-seed. After offbarding your SEED device, create a [service-request]: https://go.gov.sg/seed-techpass-support. Upon verification, we will teminate the TechPass account.
+If you have a SEED device, offboard your SEED device by following the [offboarding guide](https://docs.developer.tech.gov.sg/docs/security-suite-for-engineering-endpoint-devices/offboard-device/offboard-device-from-seed). After offbarding your SEED device, create a [service-request](https://go.gov.sg/seed-techpass-support). Upon verification, we will teminate the TechPass account.
 
-If you do not have a SEED device, create a [service-request]: https://go.gov.sg/seed-techpass-support. Upon verification, we will teminate the TechPass account.
+If you do not have a SEED device, create a [service-request](https://go.gov.sg/seed-techpass-support). Upon verification, we will teminate the TechPass account.
 
 
 <hr/></details><br>


### PR DESCRIPTION
Story 1:
An issue brought up by Victor from GCC2 TechOps, some people who changed their email address (staff movement) need more clarity on what they should do to fix their TechPass account. Typically the WoG AAD account and their TechPass account don't work anymore, until they create an SR and we reinvite them to fix the external IDs. Victor has to go back and forth with the users for weeks to figure out the proper process. The instructions need to be in Techpass User Guide.

Story 2:
When users want to terminate their account they'll need instructions in Techpass User Guide.